### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HubSpot MCP Server
 
+[![smithery badge](https://smithery.ai/badge/buryhuang/mcp-hubspot)](https://smithery.ai/server/buryhuang/mcp-hubspot)
+
 ## Overview
 
 A Model Context Protocol (MCP) server implementation that provides integration with HubSpot CRM. This server enables AI models to interact with HubSpot data and operations through a standardized interface.
@@ -108,6 +110,14 @@ The server offers several tools for managing HubSpot objects:
 
 
 ## Setup
+
+### Installing via Smithery
+
+To install buryhuang/mcp-hubspot for Claude Desktop automatically via [Smithery](https://smithery.ai/server/buryhuang/mcp-hubspot):
+
+```bash
+npx -y @smithery/cli install buryhuang/mcp-hubspot --client claude
+```
 
 ### Prerequisites
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install buryhuang/mcp-hubspot for Claude Desktop using Smithery CLI. This provides an easy method for users to install the MCP.
2. Adds a badge to display the number of installations from Smithery: https://smithery.ai/server/buryhuang/mcp-hubspot

Let me know if any tweaks have to be made!