### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # HubSpot MCP Server
+[![smithery badge](https://smithery.ai/badge/mcp-hubspot)](https://smithery.ai/server/mcp-hubspot/prod)
 
 ## Overview
 
@@ -185,6 +186,14 @@ To publish the Docker image for multiple platforms, you can use the `docker buil
 
 
 ## Usage with Claude Desktop
+
+### Installing via Smithery
+
+To install mcp-hubspot for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-hubspot/prod):
+
+```bash
+npx @smithery/cli@latest install mcp-hubspot --client claude
+```
 
 ### Docker Usage
 ```json

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ To publish the Docker image for multiple platforms, you can use the `docker buil
 To install mcp-hubspot for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-hubspot/prod):
 
 ```bash
-npx @smithery/cli@latest install mcp-hubspot --client claude
+npx -y @smithery/cli@latest install mcp-hubspot --client claude
 ```
 
 ### Docker Usage

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - hubspotAccessToken
+    properties:
+      hubspotAccessToken:
+        type: string
+        description: The access token for the HubSpot API.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({ command: 'docker', args: ['run', '--rm', '-e', `HUBSPOT_ACCESS_TOKEN=${config.hubspotAccessToken}`, 'buryhuang/mcp-hubspot:latest'] })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML configuration file, which specifies how to start the MCP and the configuration options it supports. This enables hosting the MCP server on [Smithery](https://smithery.ai) and allows users to connect to the hosted version over SSE without additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/mcp-hubspot) and claiming it.
- **README**: Updates the README to include a popularity badge.

Please review these updates to verify their accuracy for your server. Let us know if you have any questions. 🙂